### PR TITLE
feat: Phase 6 & 7 — Legal Pages, SEO & Performance (#9, #10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,67 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Primary Meta Tags -->
+    <title>Terpafy — Assistente Digital de Cannabis Medicinal</title>
     <meta
       name="description"
       content="Terpafy — seu assistente digital de saúde para tratamento com cannabis medicinal. Ciência e cuidado na palma da sua mão."
     />
-    <meta property="og:title" content="Terpafy" />
+    <meta
+      name="keywords"
+      content="cannabis medicinal, cultivo cannabis, WhatsApp assistente, saúde, terpenos, LGPD, Brasil"
+    />
+    <meta name="author" content="Terpafy" />
+    <meta name="robots" content="index, follow" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://terpafy.ai/" />
+    <meta
+      property="og:title"
+      content="Terpafy — Assistente Digital de Cannabis Medicinal"
+    />
     <meta
       property="og:description"
-      content="Terpafy — seu assistente digital de saúde para tratamento com cannabis medicinal."
+      content="Terpafy — seu assistente digital de saúde para tratamento com cannabis medicinal. Ciência e cuidado na palma da sua mão."
     />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="/og-image.png" />
-    <title>Terpafy</title>
+    <meta property="og:image" content="https://terpafy.ai/og-image.png" />
+    <meta property="og:locale" content="pt_BR" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="es_ES" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Terpafy — Assistente Digital de Cannabis Medicinal"
+    />
+    <meta
+      name="twitter:description"
+      content="Terpafy — seu assistente digital de saúde para tratamento com cannabis medicinal. Ciência e cuidado na palma da sua mão."
+    />
+    <meta name="twitter:image" content="https://terpafy.ai/og-image.png" />
+
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Terpafy",
+        "url": "https://terpafy.ai",
+        "logo": "https://terpafy.ai/favicon.svg",
+        "description": "Assistente digital de saúde para tratamento com cannabis medicinal via WhatsApp",
+        "email": "terpafy.ai@gmail.com",
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "email": "terpafy.ai@gmail.com",
+          "contactType": "customer service",
+          "availableLanguage": ["Portuguese", "English", "Spanish"]
+        }
+      }
+    </script>
+
     <!-- Google Fonts: Anton (headings) + Inter (body) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://terpafy.ai/sitemap.xml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,64 @@
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { Home } from "@/pages/Home";
-import { PrivacyPolicy } from "@/pages/PrivacyPolicy";
-import { TermsOfService } from "@/pages/TermsOfService";
+
+const PrivacyPolicy = lazy(() =>
+  import("@/pages/PrivacyPolicy").then((m) => ({ default: m.PrivacyPolicy })),
+);
+const TermsOfService = lazy(() =>
+  import("@/pages/TermsOfService").then((m) => ({ default: m.TermsOfService })),
+);
+
+const LANG_MAP: Record<string, string> = {
+  pt: "pt-BR",
+  en: "en",
+  es: "es",
+};
+
+function LanguageSyncEffect() {
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    const code = i18n.language?.slice(0, 2) ?? "pt";
+    document.documentElement.lang = LANG_MAP[code] ?? code;
+  }, [i18n.language]);
+
+  return null;
+}
 
 function App() {
   return (
     <BrowserRouter>
+      <LanguageSyncEffect />
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:outline-none"
+      >
+        Pular para o conteúdo principal
+      </a>
       <div className="flex min-h-screen flex-col bg-background text-foreground">
         <Header />
-        <div className="flex-1">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/privacy" element={<PrivacyPolicy />} />
-            <Route path="/terms" element={<TermsOfService />} />
-          </Routes>
+        <div
+          id="main-content"
+          className="flex-1"
+          tabIndex={-1}
+        >
+          <Suspense
+            fallback={
+              <div className="flex min-h-[50vh] items-center justify-center">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              </div>
+            }
+          >
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/privacy" element={<PrivacyPolicy />} />
+              <Route path="/terms" element={<TermsOfService />} />
+            </Routes>
+          </Suspense>
         </div>
         <Footer />
       </div>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,10 +1,34 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
+import {
+  ArrowLeft,
+  User,
+  Database,
+  ShieldCheck,
+  Share2,
+  Lock,
+  Scale,
+  Archive,
+  Bell,
+  Mail,
+} from "lucide-react";
 import { Section } from "@/components/layout/Section";
 
+const LAST_UPDATED = new Date(2025, 0, 1);
+
 export function PrivacyPolicy() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+
+  const locale = i18n.language?.startsWith("es")
+    ? "es-ES"
+    : i18n.language?.startsWith("en")
+      ? "en-US"
+      : "pt-BR";
+
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+  }).format(LAST_UPDATED);
 
   return (
     <main className="bg-background text-foreground">
@@ -17,52 +41,289 @@ export function PrivacyPolicy() {
           {t("legal.backToHome")}
         </Link>
 
-        <article className="prose prose-neutral max-w-3xl">
-          <h1 className="font-heading text-4xl font-black">{t("privacy.title")}</h1>
+        <article className="max-w-3xl space-y-12">
+          <header>
+            <h1 className="font-heading text-4xl font-black">
+              {t("privacy.title")}
+            </h1>
+            <p className="mt-2 text-sm text-foreground-muted">
+              {t("privacy.lastUpdate")}: {formattedDate}
+            </p>
+            <p className="mt-4 leading-relaxed text-foreground-muted">
+              {t("privacy.intro")}
+            </p>
+          </header>
 
-          <p>{t("privacy.intro")}</p>
+          {/* Section 1 — Identification */}
+          <section aria-labelledby="privacy-s1">
+            <h2
+              id="privacy-s1"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <User className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section1.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>{t("privacy.section1.description")}</p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section1.status")}
+                </strong>
+                : {t("privacy.section1.statusText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section1.contact")}
+                </strong>
+                :{" "}
+                <a
+                  href="mailto:terpafy.ai@gmail.com"
+                  className="font-medium text-primary hover:underline"
+                >
+                  terpafy.ai@gmail.com
+                </a>
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("privacy.section1.title")}</h2>
-          <p>{t("privacy.section1.description")}</p>
-          <p>
-            <strong>{t("privacy.section1.status")}</strong>:{" "}
-            {t("privacy.section1.statusText")}
-          </p>
+          {/* Section 2 — Data Collected */}
+          <section aria-labelledby="privacy-s2">
+            <h2
+              id="privacy-s2"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Database className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section2.title")}
+            </h2>
+            <div className="space-y-4 text-foreground-muted">
+              <p className="leading-relaxed">{t("privacy.section2.description")}</p>
+              <div className="overflow-x-auto rounded-lg border border-foreground-muted/20">
+                <table className="w-full table-auto text-sm">
+                  <thead className="bg-foreground/5">
+                    <tr>
+                      <th className="px-4 py-3 text-left font-semibold text-foreground">
+                        {t("privacy.section2.table.category")}
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-foreground">
+                        {t("privacy.section2.table.examples")}
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-foreground">
+                        {t("privacy.section2.table.purpose")}
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-foreground">
+                        {t("privacy.section2.table.legal")}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-foreground-muted/10">
+                    <tr>
+                      <td className="px-4 py-3 font-medium text-foreground">
+                        {t("privacy.section2.table.personal")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.personalExamples")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.personalPurpose")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.personalLegal")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-4 py-3 font-medium text-foreground">
+                        {t("privacy.section2.table.sensitive")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.sensitiveExamples")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.sensitivePurpose")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.sensitiveLegal")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="px-4 py-3 font-medium text-foreground">
+                        {t("privacy.section2.table.usage")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.usageExamples")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.usagePurpose")}
+                      </td>
+                      <td className="px-4 py-3">
+                        {t("privacy.section2.table.usageLegal")}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
 
-          <h2>{t("privacy.section2.title")}</h2>
-          <p>{t("privacy.section2.description")}</p>
+          {/* Section 3 — Sensitive Data */}
+          <section aria-labelledby="privacy-s3">
+            <h2
+              id="privacy-s3"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <ShieldCheck className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section3.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>{t("privacy.section3.description")}</p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section3.consent")}
+                </strong>
+                : {t("privacy.section3.consentText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section3.anonymization")}
+                </strong>
+                : {t("privacy.section3.anonymizationText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("privacy.section3.title")}</h2>
-          <p>{t("privacy.section3.description")}</p>
-          <p>
-            <strong>{t("privacy.section3.consent")}</strong>:{" "}
-            {t("privacy.section3.consentText")}
-          </p>
+          {/* Section 4 — Data Sharing */}
+          <section aria-labelledby="privacy-s4">
+            <h2
+              id="privacy-s4"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Share2 className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section4.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>{t("privacy.section4.description")}</p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section4.doctor")}
+                </strong>
+                : {t("privacy.section4.doctorText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section4.operators")}
+                </strong>
+                : {t("privacy.section4.operatorsText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section4.legal")}
+                </strong>
+                : {t("privacy.section4.legalText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("privacy.section4.title")}</h2>
-          <p>{t("privacy.section4.description")}</p>
+          {/* Section 5 — Security */}
+          <section aria-labelledby="privacy-s5">
+            <h2
+              id="privacy-s5"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Lock className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section5.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>{t("privacy.section5.description")}</p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section5.measures")}
+                </strong>
+                : {t("privacy.section5.measuresText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section5.risk")}
+                </strong>
+                : {t("privacy.section5.riskText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("privacy.section5.whatsapp")}
+                </strong>
+                : {t("privacy.section5.whatsappText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("privacy.section5.title")}</h2>
-          <p>{t("privacy.section5.description")}</p>
+          {/* Section 6 — Rights */}
+          <section aria-labelledby="privacy-s6">
+            <h2
+              id="privacy-s6"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Scale className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section6.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>{t("privacy.section6.description")}</p>
+              <ul className="list-disc space-y-2 pl-6">
+                <li>{t("privacy.section6.right1")}</li>
+                <li>{t("privacy.section6.right2")}</li>
+                <li>{t("privacy.section6.right3")}</li>
+                <li>{t("privacy.section6.right4")}</li>
+                <li>{t("privacy.section6.right5")}</li>
+              </ul>
+            </div>
+          </section>
 
-          <h2>{t("privacy.section6.title")}</h2>
-          <p>{t("privacy.section6.description")}</p>
-          <ul>
-            <li>{t("privacy.section6.right1")}</li>
-            <li>{t("privacy.section6.right2")}</li>
-            <li>{t("privacy.section6.right3")}</li>
-            <li>{t("privacy.section6.right4")}</li>
-            <li>{t("privacy.section6.right5")}</li>
-          </ul>
+          {/* Section 7 — Retention */}
+          <section aria-labelledby="privacy-s7">
+            <h2
+              id="privacy-s7"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Archive className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section7.title")}
+            </h2>
+            <p className="leading-relaxed text-foreground-muted">
+              {t("privacy.section7.description")}
+            </p>
+          </section>
 
-          <h2>{t("privacy.section7.title")}</h2>
-          <p>{t("privacy.section7.description")}</p>
+          {/* Section 8 — Changes */}
+          <section aria-labelledby="privacy-s8">
+            <h2
+              id="privacy-s8"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Bell className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.section8.title")}
+            </h2>
+            <p className="leading-relaxed text-foreground-muted">
+              {t("privacy.section8.description")}
+            </p>
+          </section>
 
-          <h2>{t("privacy.section8.title")}</h2>
-          <p>{t("privacy.section8.description")}</p>
-
-          <h2>{t("privacy.contact.title")}</h2>
-          <p>{t("privacy.contact.description")}</p>
+          {/* Contact */}
+          <section aria-labelledby="privacy-contact">
+            <h2
+              id="privacy-contact"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Mail className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("privacy.contact.title")}
+            </h2>
+            <div className="space-y-2 leading-relaxed text-foreground-muted">
+              <p>{t("privacy.contact.description")}</p>
+              <p>
+                <a
+                  href="mailto:terpafy.ai@gmail.com"
+                  className="font-medium text-primary hover:underline"
+                >
+                  terpafy.ai@gmail.com
+                </a>
+              </p>
+            </div>
+          </section>
         </article>
       </Section>
     </main>

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,10 +1,31 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
+import {
+  ArrowLeft,
+  Smartphone,
+  MessageSquare,
+  FileText,
+  AlertTriangle,
+  FileCheck,
+  Mail,
+} from "lucide-react";
 import { Section } from "@/components/layout/Section";
 
+const LAST_UPDATED = new Date(2025, 0, 1);
+
 export function TermsOfService() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+
+  const locale = i18n.language?.startsWith("es")
+    ? "es-ES"
+    : i18n.language?.startsWith("en")
+      ? "en-US"
+      : "pt-BR";
+
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+  }).format(LAST_UPDATED);
 
   return (
     <main className="bg-background text-foreground">
@@ -17,60 +38,217 @@ export function TermsOfService() {
           {t("legal.backToHome")}
         </Link>
 
-        <article className="prose prose-neutral max-w-3xl">
-          <h1 className="font-heading text-4xl font-black">{t("terms.title")}</h1>
+        <article className="max-w-3xl space-y-12">
+          <header>
+            <h1 className="font-heading text-4xl font-black">
+              {t("terms.title")}
+            </h1>
+            <p className="mt-2 text-sm text-foreground-muted">
+              {t("terms.lastUpdate")}: {formattedDate}
+            </p>
+            <p className="mt-4 leading-relaxed text-foreground-muted">
+              {t("terms.intro")}
+            </p>
+          </header>
 
-          <p>{t("terms.intro")}</p>
+          {/* Section 1 — Service Description */}
+          <section aria-labelledby="terms-s1">
+            <h2
+              id="terms-s1"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Smartphone className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.section1.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section1.nature")}
+                </strong>
+                : {t("terms.section1.natureText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section1.limitation")}
+                </strong>
+                : {t("terms.section1.limitationText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section1.mvp")}
+                </strong>
+                : {t("terms.section1.mvpText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("terms.section1.title")}</h2>
-          <p>
-            <strong>{t("terms.section1.nature")}</strong>:{" "}
-            {t("terms.section1.natureText")}
-          </p>
-          <p>
-            <strong>{t("terms.section1.limitation")}</strong>:{" "}
-            {t("terms.section1.limitationText")}
-          </p>
-          <p>
-            <strong>{t("terms.section1.mvp")}</strong>:{" "}
-            {t("terms.section1.mvpText")}
-          </p>
+          {/* Section 2 — Use of Service */}
+          <section aria-labelledby="terms-s2">
+            <h2
+              id="terms-s2"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <MessageSquare className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.section2.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section2.platform")}
+                </strong>
+                : {t("terms.section2.platformText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section2.communication")}
+                </strong>
+                : {t("terms.section2.communicationText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section2.responsibility")}
+                </strong>
+                : {t("terms.section2.responsibilityText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("terms.section2.title")}</h2>
-          <p>
-            <strong>{t("terms.section2.platform")}</strong>:{" "}
-            {t("terms.section2.platformText")}
-          </p>
-          <p>
-            <strong>{t("terms.section2.responsibility")}</strong>:{" "}
-            {t("terms.section2.responsibilityText")}
-          </p>
+          {/* Section 3 — Intellectual Property */}
+          <section aria-labelledby="terms-s3">
+            <h2
+              id="terms-s3"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <FileText className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.section3.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section3.content")}
+                </strong>
+                : {t("terms.section3.contentText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section3.usage")}
+                </strong>
+                : {t("terms.section3.usageText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("terms.section3.title")}</h2>
-          <p>{t("terms.section3.contentText")}</p>
+          {/* Section 4 — Liability */}
+          <section aria-labelledby="terms-s4">
+            <h2
+              id="terms-s4"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <AlertTriangle className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.section4.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+                <p className="text-sm font-semibold text-foreground">
+                  {t("terms.section4.critical")}
+                </p>
+              </div>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section4.noGuarantee")}
+                </strong>
+                : {t("terms.section4.noGuaranteeText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section4.noCNPJ")}
+                </strong>
+                : {t("terms.section4.noCNPJText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section4.damages")}
+                </strong>
+                : {t("terms.section4.damagesText")}
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("terms.section4.title")}</h2>
-          <p>
-            <strong>{t("terms.section4.noGuarantee")}</strong>:{" "}
-            {t("terms.section4.noGuaranteeText")}
-          </p>
-          <p>
-            <strong>{t("terms.section4.damages")}</strong>:{" "}
-            {t("terms.section4.damagesText")}
-          </p>
+          {/* Section 5 — General Provisions */}
+          <section aria-labelledby="terms-s5">
+            <h2
+              id="terms-s5"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <FileCheck className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.section5.title")}
+            </h2>
+            <div className="space-y-3 leading-relaxed text-foreground-muted">
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section5.acceptance")}
+                </strong>
+                : {t("terms.section5.acceptanceText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section5.changes")}
+                </strong>
+                : {t("terms.section5.changesText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section5.law")}
+                </strong>
+                : {t("terms.section5.lawText")}
+              </p>
+              <p>
+                <strong className="text-foreground">
+                  {t("terms.section5.jurisdiction")}
+                </strong>
+                : Goiânia, Goiás, Brasil
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("terms.section5.title")}</h2>
-          <p>
-            <strong>{t("terms.section5.acceptance")}</strong>:{" "}
-            {t("terms.section5.acceptanceText")}
-          </p>
-          <p>
-            <strong>{t("terms.section5.law")}</strong>:{" "}
-            {t("terms.section5.lawText")}
-          </p>
+          {/* Contact */}
+          <section aria-labelledby="terms-contact">
+            <h2
+              id="terms-contact"
+              className="mb-4 flex items-center gap-2 text-xl font-bold"
+            >
+              <Mail className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.contact.title")}
+            </h2>
+            <div className="space-y-2 leading-relaxed text-foreground-muted">
+              <p>{t("terms.contact.description")}</p>
+              <p>
+                <a
+                  href="mailto:terpafy.ai@gmail.com"
+                  className="font-medium text-primary hover:underline"
+                >
+                  terpafy.ai@gmail.com
+                </a>
+              </p>
+            </div>
+          </section>
 
-          <h2>{t("terms.contact.title")}</h2>
-          <p>{t("terms.contact.description")}</p>
+          {/* Legal Disclaimer */}
+          <aside
+            aria-labelledby="terms-disclaimer"
+            className="rounded-lg border border-foreground-muted/20 bg-foreground/5 p-5"
+          >
+            <h2
+              id="terms-disclaimer"
+              className="mb-2 flex items-center gap-2 text-base font-bold"
+            >
+              <AlertTriangle className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+              {t("terms.disclaimer.title")}
+            </h2>
+            <p className="text-sm leading-relaxed text-foreground-muted">
+              {t("terms.disclaimer.text")}
+            </p>
+          </aside>
         </article>
       </Section>
     </main>


### PR DESCRIPTION
## Summary

Implements Phase 6 (Legal Pages) and Phase 7 (SEO & Performance) on top of the Phases 1–5 rewrite.

---

## Issues

Closes #9
Closes #10

---

## Phase 6 — Legal Pages (#9)

### `PrivacyPolicy.tsx`
- All 8 sections rendered — including previously missing data collection table (section 2), anonymization (section 3), sharing sub-items (section 4), security detail (section 5)
- Section icons via `lucide-react`
- `lastUpdate` formatted per locale (`Intl.DateTimeFormat`)
- `terpafy.ai@gmail.com` as `mailto:` link

### `TermsOfService.tsx`
- All 5 sections + full disclaimer — including `communication` (s2), `noCNPJ` + critical callout (s4), `changes` + `jurisdiction` (s5), `disclaimer` aside
- Section 4 critical notice as highlighted callout box

## Phase 7 — SEO & Performance (#10)

### `index.html`
- Full meta set: `keywords`, `author`, `robots`
- Open Graph with absolute URLs, `og:locale` + alternates (pt_BR, en_US, es_ES)
- Twitter Card (`summary_large_image`)
- JSON-LD Organization schema

### `public/robots.txt`
- `User-agent: * / Allow: / / Sitemap: https://terpafy.ai/sitemap.xml`

### `App.tsx`
- Legal pages lazy-loaded (confirmed separate JS chunks: `PrivacyPolicy` 10 kB, `TermsOfService` 7 kB)
- `LanguageSyncEffect` updates `html[lang]` on language switch
- Skip-to-content link for keyboard users

---

## Checks

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean (6 chunks, 2.17s)