### PR TITLE
feat: Phase 8 & 9 — CI/CD update & final cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # WhatsApp number for CTA button (digits only, with country code, no + sign)
+# Example: 5511999999999 (Brazil country code 55 + area code + number)
 VITE_WHATSAPP_NUMBER=
+
+# Courier API base URL (reserved for future use)
+VITE_API_URL=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,33 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
+      - name: Type check
         run: pnpm typecheck
 
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -1,15 +1,138 @@
 # Terpafy Landing Page
 
-Site institucional da Terpafy — assistente digital de saúde para tratamento com cannabis medicinal.
+Institutional landing page for **Terpafy** — a digital health assistant for medicinal cannabis treatment via WhatsApp.
 
-> **Em construção** — veja o [plano de implementação](docs/REWRITE_PLAN.md) para detalhes.
+🌐 **Live**: [terpafy.ai](https://terpafy.ai)
 
-## Desenvolvimento
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | React 19 |
+| Language | TypeScript 5 |
+| Build tool | Vite 7 |
+| Styling | Tailwind CSS v4 (CSS-first, `@theme`) |
+| Components | shadcn/ui (Radix primitives) |
+| i18n | i18next + react-i18next (PT / EN / ES) |
+| Routing | React Router v7 |
+| Deployment | GitHub Pages (auto-deploy on push to `main`) |
+
+---
+
+## Quick Start
 
 ```bash
 pnpm install
-pnpm dev        # localhost:5173
-pnpm build      # dist/
-pnpm typecheck  # verificação de tipos
-pnpm lint       # ESLint
+pnpm dev        # http://localhost:5173
 ```
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and fill in values:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Description |
+|----------|-------------|
+| `VITE_WHATSAPP_NUMBER` | WhatsApp phone number for CTA buttons (digits only, with country code, no `+`) |
+| `VITE_API_URL` | Courier API base URL (optional, reserved for future use) |
+
+---
+
+## Available Scripts
+
+```bash
+pnpm dev          # Start dev server at localhost:5173
+pnpm build        # Production build → dist/
+pnpm preview      # Preview production build locally
+pnpm typecheck    # TypeScript type checking (tsc -b --noEmit)
+pnpm lint         # ESLint
+pnpm format       # Prettier (write)
+pnpm format:check # Prettier (check only)
+```
+
+---
+
+## Design System
+
+### Color Tokens
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-primary` | `#f2594b` | Terpafy Pulse (Red) — CTAs, accents |
+| `--color-secondary` | `#eaf205` | Signal Intelligence (Yellow) — highlights |
+| `--color-accent` | `#0aeded` | Connected Flow (Cyan) — badges |
+| `--color-accent-green` | `#93a603` | Living Science (Olive) — nature elements |
+| `--color-background` | `#f6f6f6` | Page background |
+| `--color-foreground` | `#3a3a3a` | Primary text |
+
+All tokens live in `src/index.css` under `@theme`.
+
+### Typography
+
+- **Headings**: Anton (Google Fonts) — `font-heading`
+- **Body**: Inter (Google Fonts) — `font-body`
+
+---
+
+## Project Structure
+
+```
+src/
+├── App.tsx                  # Router + global layout + lazy loading
+├── main.tsx                 # Entry point, i18n init
+├── index.css                # Tailwind v4 @theme tokens
+├── components/
+│   ├── common/              # Logo, LanguageSwitcher, WhatsAppButton
+│   ├── layout/              # Header, Footer, Section
+│   ├── sections/            # Hero, Features, HowItWorks, Benefits, CTA
+│   └── ui/                  # shadcn/ui primitives (Button, Card, Badge…)
+├── pages/
+│   ├── Home.tsx             # Composes all homepage sections
+│   ├── PrivacyPolicy.tsx    # Privacy policy (8 sections, LGPD)
+│   └── TermsOfService.tsx   # Terms of service (5 sections + disclaimer)
+├── i18n/
+│   ├── config.ts            # i18next setup (PT default, browser detection)
+│   └── locales/             # pt.json, en.json, es.json
+├── hooks/                   # Custom React hooks
+├── types/                   # TypeScript interfaces
+└── lib/                     # Utilities (cn, etc.)
+public/
+├── CNAME                    # terpafy.ai
+├── favicon.svg
+└── robots.txt               # Allow all, sitemap link
+.github/
+└── workflows/
+    └── deploy.yml           # CI: typecheck → lint → build → deploy to Pages
+```
+
+---
+
+## Deployment
+
+Deploys automatically to **GitHub Pages** on every push to `main`.
+
+Pipeline (`.github/workflows/deploy.yml`):
+1. `pnpm install --frozen-lockfile`
+2. `pnpm typecheck`
+3. `pnpm lint`
+4. `pnpm build` → `dist/`
+5. Upload artifact → Deploy to Pages
+
+---
+
+## Contributing
+
+**Branch naming**: `feat/`, `fix/`, `refactor/`, `chore/` prefixes.
+
+**Commit style**: `type: short description (#issue)`
+
+**Before opening a PR**, ensure all checks pass locally:
+```bash
+pnpm typecheck && pnpm lint && pnpm build
+```
+

--- a/src/components/common/WhatsAppButton.tsx
+++ b/src/components/common/WhatsAppButton.tsx
@@ -2,8 +2,7 @@ import { useTranslation } from "react-i18next";
 import { MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const WHATSAPP_NUMBER =
-  import.meta.env.VITE_WHATSAPP_NUMBER ?? "5511960011592";
+const WHATSAPP_NUMBER = import.meta.env.VITE_WHATSAPP_NUMBER ?? "";
 
 interface WhatsAppButtonProps {
   /** "primary" = large full-width-ish CTA button | "inline" = ghost-like link */

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,8 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Logo } from "@/components/common/Logo";
 import { WhatsAppButton } from "@/components/common/WhatsAppButton";
 
-const WHATSAPP_NUMBER =
-  import.meta.env.VITE_WHATSAPP_NUMBER ?? "5511960011592";
+const WHATSAPP_NUMBER = import.meta.env.VITE_WHATSAPP_NUMBER ?? "";
 
 /**
  * Site footer — matches Figma: coral/red background, logo, tagline,


### PR DESCRIPTION
## Summary

Closes #11 — Phase 8: CI/CD Pipeline update
Closes #12 — Phase 9: Documentation & Final Cleanup

## Changes

### Phase 8 — CI/CD (.github/workflows/deploy.yml)
- Use `pnpm/action-setup@v4` before `actions/setup-node` for correct ordering
- Leverage built-in `cache: "pnpm"` on setup-node (removes manual cache steps)
- Standardised step names: "Install pnpm", "Setup Node.js", "Type check", "Lint"

### Phase 9 — Documentation & Cleanup
- **README.md**: Full rewrite — tech stack table, quick start, env vars, scripts, design system tokens, project structure, deployment overview, contributing guide
- **.env.example**: Added `VITE_API_URL` placeholder + descriptive comments
- **Security**: Removed hardcoded WhatsApp number fallback (`"5511960011592"`) from `Footer.tsx` and `WhatsAppButton.tsx` — number is now exclusively sourced from `VITE_WHATSAPP_NUMBER` env var

## Checks
- ✅ `pnpm typecheck`
- ✅ `pnpm lint`
- ✅ `pnpm build`